### PR TITLE
feat: add sampler and return_study parameters to tuning function

### DIFF
--- a/xgboostlss/model.py
+++ b/xgboostlss/model.py
@@ -325,6 +325,8 @@ class XGBoostLSS:
         silence=False,
         seed=None,
         hp_seed=None,
+        sampler = None,
+        return_study = False
     ):
         """
         Function to tune hyperparameters using optuna.
@@ -452,11 +454,12 @@ class XGBoostLSS:
 
         if silence:
             optuna.logging.set_verbosity(optuna.logging.WARNING)
-
-        if hp_seed is not None:
-            sampler = TPESampler(seed=hp_seed)
-        else:
-            sampler = TPESampler()
+            
+        if sampler is None:  
+            if hp_seed is not None:
+                sampler = TPESampler(seed=hp_seed)
+            else:
+                sampler = TPESampler()
 
         pruner = optuna.pruners.MedianPruner(n_startup_trials=10, n_warmup_steps=20)
         study = optuna.create_study(sampler=sampler, pruner=pruner, direction="minimize", study_name=study_name)
@@ -476,8 +479,11 @@ class XGBoostLSS:
         print("    Params: ")
         for key, value in opt_param.params.items():
             print("    {}: {}".format(key, value))
-
-        return opt_param.params
+            
+        if return_study:
+            return opt_param.params, study
+        else:
+            return opt_param.params
 
     def predict(
         self,


### PR DESCRIPTION
## Summary
This PR adds support for passing `sampler` and `return_study` parameters to the tuning function.

## Changes
- Added `sampler` parameter to allow custom Optuna samplers.
- Added `return_study` parameter to optionally return the Optuna study object.
- Updated the tuning function to handle the new parameters.
- Maintained backward compatibility with existing functionality.

## Testing
- Verified existing functionality remains unchanged.
- Confirmed custom samplers work correctly.
- Confirmed the study object is returned when `return_study=True`.